### PR TITLE
Improve dataset display and file handling

### DIFF
--- a/seg_qc_tool/controller.py
+++ b/seg_qc_tool/controller.py
@@ -128,6 +128,10 @@ class Controller(QtCore.QObject):
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(str(src), str(dest))
 
+        # Clear cached volumes so file handles are released on Windows
+        from .io_utils import load_volume
+        load_volume.cache_clear()
+
         # Log the exact file that was copied so the filename is preserved
         with open("discard_log.csv", "a", newline="") as f:
             writer = csv.writer(f)

--- a/seg_qc_tool/gui.py
+++ b/seg_qc_tool/gui.py
@@ -68,7 +68,16 @@ class MainWindow(QtWidgets.QMainWindow):
         splitter = QtWidgets.QSplitter()
         splitter.addWidget(self.left_view)
         splitter.addWidget(self.right_view)
-        self.setCentralWidget(splitter)
+
+        self.dataset_label = QtWidgets.QLabel("")
+        self.dataset_label.setAlignment(QtCore.Qt.AlignCenter)
+
+        container = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(container)
+        layout.addWidget(self.dataset_label)
+        layout.addWidget(splitter)
+        layout.setStretchFactor(splitter, 1)
+        self.setCentralWidget(container)
 
         nav = QtWidgets.QToolBar()
         self.addToolBar(QtCore.Qt.ToolBarArea.BottomToolBarArea, nav)
@@ -103,6 +112,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.slice_slider.valueChanged.connect(self.change_slice)
 
     def load_pair(self, pair: Pair) -> None:
+        self.dataset_label.setText(pair.original.name)
         volume = self._load_volume(pair.original)
         seg = self._load_volume(pair.segmentation)
         if volume.ndim == 3:

--- a/seg_qc_tool/io_utils.py
+++ b/seg_qc_tool/io_utils.py
@@ -21,9 +21,18 @@ logger = logging.getLogger(__name__)
 
 
 def load_nifti(path: Path) -> np.ndarray:  # pragma: no cover - heavy I/O
-    """Load a NIfTI file as a numpy array."""
+    """Load a NIfTI file as a numpy array and close the file handle."""
     img = nib.load(str(path))
     data = img.get_fdata(dtype=np.float32)
+    if data.ndim == 4:
+        data = data[..., 0]
+    if data.ndim == 3:
+        data = np.transpose(data, (2, 0, 1))
+    # Explicitly close any open file handles held by nibabel
+    if hasattr(img, "file_map"):
+        for fh in img.file_map.values():
+            if fh.fileobj:
+                fh.fileobj.close()
     return np.asarray(data)
 
 
@@ -60,26 +69,26 @@ def load_dicom_series(path: Path, *, return_files: bool = False) -> Union[np.nda
     if not files:
         raise FileNotFoundError("No DICOM files found")
 
-    datasets: List[pydicom.Dataset] = [pydicom.dcmread(str(f)) for f in files]
-    try:
-        pairs = sorted(
-            zip(datasets, files),
-            key=lambda t: int(getattr(t[0], "InstanceNumber", 0)),
-        )
-        datasets, files = [list(x) for x in zip(*pairs)]
-    except Exception:  # pragma: no cover - best effort sorting
-        pass
-
-    arrays = []
-    for ds in datasets:
+    slices = []
+    for f in files:
+        ds = pydicom.dcmread(str(f))
+        inst_num = int(getattr(ds, "InstanceNumber", 0))
         arr = ds.pixel_array.astype(np.float32)
         slope = float(getattr(ds, "RescaleSlope", 1.0))
         intercept = float(getattr(ds, "RescaleIntercept", 0.0))
         arr = arr * slope + intercept
-        arrays.append(arr)
+        photometric = getattr(ds, "PhotometricInterpretation", "")
+        if hasattr(ds, "close"):
+            ds.close()
+        slices.append((inst_num, arr, photometric, f))
+
+    slices.sort(key=lambda t: t[0])
+    arrays = [s[1] for s in slices]
+    files = [s[3] for s in slices]
+    photometric = slices[0][2] if slices else ""
 
     volume = np.stack(arrays)
-    if datasets and datasets[0].get("PhotometricInterpretation") == "MONOCHROME1":
+    if photometric == "MONOCHROME1":
         volume = volume.max() - volume
     if return_files:
         return volume, files

--- a/seg_qc_tool/io_utils.py
+++ b/seg_qc_tool/io_utils.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 def load_nifti(path: Path) -> np.ndarray:  # pragma: no cover - heavy I/O
     """Load a NIfTI file as a numpy array and close the file handle."""
-    img = nib.load(str(path))
+    img = nib.load(str(path), mmap=False)
     data = img.get_fdata(dtype=np.float32)
     if data.ndim == 4:
         data = data[..., 0]

--- a/seg_qc_tool/io_utils.py
+++ b/seg_qc_tool/io_utils.py
@@ -71,15 +71,14 @@ def load_dicom_series(path: Path, *, return_files: bool = False) -> Union[np.nda
 
     slices = []
     for f in files:
-        ds = pydicom.dcmread(str(f))
-        inst_num = int(getattr(ds, "InstanceNumber", 0))
-        arr = ds.pixel_array.astype(np.float32)
-        slope = float(getattr(ds, "RescaleSlope", 1.0))
-        intercept = float(getattr(ds, "RescaleIntercept", 0.0))
-        arr = arr * slope + intercept
-        photometric = getattr(ds, "PhotometricInterpretation", "")
-        if hasattr(ds, "close"):
-            ds.close()
+        with open(f, "rb") as fp:
+            ds = pydicom.dcmread(fp)
+            inst_num = int(getattr(ds, "InstanceNumber", 0))
+            arr = ds.pixel_array.astype(np.float32)
+            slope = float(getattr(ds, "RescaleSlope", 1.0))
+            intercept = float(getattr(ds, "RescaleIntercept", 0.0))
+            arr = arr * slope + intercept
+            photometric = getattr(ds, "PhotometricInterpretation", "")
         slices.append((inst_num, arr, photometric, f))
 
     slices.sort(key=lambda t: t[0])

--- a/seg_qc_tool/matcher.py
+++ b/seg_qc_tool/matcher.py
@@ -56,7 +56,12 @@ def pair_finder(original_dir: Path, seg_dir: Path, max_dist: int = 2) -> List[Pa
     segs = _volume_items(seg_dir)
     pairs = []
     used_segs = set()
+    force_pair = len(originals) == 1 and len(segs) == 1
     for orig in originals:
+        if force_pair:
+            pairs.append(Pair(orig, segs[0]))
+            used_segs.add(segs[0])
+            continue
         base_orig = _strip_suffix(orig.stem)
         best = None
         best_dist = max_dist + 1


### PR DESCRIPTION
## Summary
- display the current dataset name above the image views
- close NIfTI and DICOM files after reading to avoid permission errors
- pair single original/segmentation volumes even if names differ

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684aeb1acc1c832f8d9d1f0c2478253d